### PR TITLE
Allow url with path to be used with this client

### DIFF
--- a/octorest/client.py
+++ b/octorest/client.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from urllib import parse as urlparse
 
 import requests
+from requests_futures.sessions import FuturesSession
 
 
 class OctoRest:
@@ -51,7 +52,8 @@ class OctoRest:
         Returns JSON decoded data
         """
         url = urlparse.urljoin(self.url, path)
-        response = self.session.get(url, params=params)
+        future_session = FuturesSession(session=self.session)
+        response = future_session.get(url, params=params).result()
         self._check_response(response)
 
         return response.json()


### PR DESCRIPTION
This allows the use of a url such as the following:-

https://www.aprinter.org:4443/octoprint/
https://www.aprinter.org:4443/octoprint2/
