### PR TITLE
Application Keys Plugin workflow support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ sdist
 
 # VS Code
 .vscode
+
+# Environments
+env/

--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,14 @@ A check list of the features currently implemented can be seen below.
     
       - [ ] Obtaining a temporary session key
       - [ ] Verifying a temporary session key
+    - [ ] Application Keys Plugin workflow
+      
+      - [X] Probe workflow support
+      - [X] Start authorization process
+      - [X] Poll for decision on existing request
+      - [ ] Decide on existing request
+      - [ ] Fetch list of existing application keys
+      - [ ] Issue an application key command
 * Connection handling
     - [X] Get connection settings
     - [X] Issue a connection command

--- a/examples/application_keys_plugin_workflow/application_keys_plugin_workflow.py
+++ b/examples/application_keys_plugin_workflow/application_keys_plugin_workflow.py
@@ -1,0 +1,34 @@
+from octorest import OctoRest, WorkflowAppKeyRequestResult
+
+def main():
+    url = "http://octopi.local"
+    user = "user"
+    
+    client = None
+
+    try:
+        client = OctoRest(url=url)
+    except TypeError:
+        raise NotImplementedError() # Decide what should happen now
+
+    (result, apiKey) = (None, None)
+
+    try:
+        (result, apiKey) = client.tryGetApiKey('my-app', user)
+    except ConnectionError:
+        raise NotImplementedError() # Decide what should happen now. Suggestion - tell the user the OctoPrint server is unreachable and that he should check the URL entered
+
+    if result == WorkflowAppKeyRequestResult.WORKFLOW_UNSUPPORTED:
+        raise NotImplementedError() # Decide what should happen now. Suggestion - fall back to asking the user to manually enter a valid API key.
+    elif result == WorkflowAppKeyRequestResult.TIMED_OUT: # The user took too long to approve the API key request
+        raise NotImplementedError() # Decide what should happen now
+    elif result == WorkflowAppKeyRequestResult.NOPE: # The request has been denied
+        raise NotImplementedError() # Decide what should happen now
+    elif result == WorkflowAppKeyRequestResult.GRANTED:
+        client.loadApiKey(apiKey) # You have to load the API key before sending any requests to the OctoPrint server
+        pass # At this point you can use the client for whatever you wish
+    
+    raise NotImplementedError() # Decide what should happen now
+
+if __name__ == "__main__":
+    main()

--- a/examples/application_keys_plugin_workflow/application_keys_plugin_workflow.py
+++ b/examples/application_keys_plugin_workflow/application_keys_plugin_workflow.py
@@ -11,10 +11,10 @@ def main():
     except TypeError:
         raise NotImplementedError() # Decide what should happen now
 
-    (result, apiKey) = (None, None)
+    (result, api_key) = (None, None)
 
     try:
-        (result, apiKey) = client.tryGetApiKey('my-app', user)
+        (result, api_key) = client.try_get_api_key('my-app', user)
     except ConnectionError:
         raise NotImplementedError() # Decide what should happen now. Suggestion - tell the user the OctoPrint server is unreachable and that he should check the URL entered
 
@@ -25,7 +25,7 @@ def main():
     elif result == WorkflowAppKeyRequestResult.NOPE: # The request has been denied
         raise NotImplementedError() # Decide what should happen now
     elif result == WorkflowAppKeyRequestResult.GRANTED:
-        client.loadApiKey(apiKey) # You have to load the API key before sending any requests to the OctoPrint server
+        client.load_api_key(api_key) # You have to load the API key before sending any requests to the OctoPrint server
         pass # At this point you can use the client for whatever you wish
     
     raise NotImplementedError() # Decide what should happen now

--- a/octorest/__init__.py
+++ b/octorest/__init__.py
@@ -1,8 +1,8 @@
-from .client import OctoRest
+from .client import OctoRest, AuthorizationRequestPollingResult
 from .xhrstreaminggenerator import XHRStreamingGenerator
 from .xhrstreaming import XHRStreamingEventHandler
 from .websocket import WebSocketEventHandler
 
 
-__all__ = ['OctoRest', 'XHRStreamingGenerator',
+__all__ = ['OctoRest','AuthorizationRequestPollingResult' , 'XHRStreamingGenerator',
            'XHRStreamingEventHandler', 'WebSocketEventHandler']

--- a/octorest/__init__.py
+++ b/octorest/__init__.py
@@ -1,8 +1,8 @@
-from .client import OctoRest, AuthorizationRequestPollingResult
+from .client import OctoRest, AuthorizationRequestPollingResult, WorkflowAppKeyRequestResult
 from .xhrstreaminggenerator import XHRStreamingGenerator
 from .xhrstreaming import XHRStreamingEventHandler
 from .websocket import WebSocketEventHandler
 
 
-__all__ = ['OctoRest','AuthorizationRequestPollingResult' , 'XHRStreamingGenerator',
-           'XHRStreamingEventHandler', 'WebSocketEventHandler']
+__all__ = ['OctoRest', 'AuthorizationRequestPollingResult', 'WorkflowAppKeyRequestResult',
+           'XHRStreamingGenerator','XHRStreamingEventHandler', 'WebSocketEventHandler']

--- a/octorest/client.py
+++ b/octorest/client.py
@@ -24,8 +24,6 @@ class OctoRest:
         """
         if not url:
             raise TypeError('Required argument \'url\' not found or emtpy')
-        if not apikey:
-            raise TypeError('Required argument \'apikey\' not found or emtpy')
 
         parsed = urlparse.urlparse(url)
         if parsed.scheme not in ['http', 'https']:
@@ -36,11 +34,13 @@ class OctoRest:
         self.url = '{}://{}'.format(parsed.scheme, parsed.netloc)
 
         self.session = session or requests.Session()
-        self.session.headers.update({'X-Api-Key': apikey})
+        
+        if apikey:
+            self.session.headers.update({'X-Api-Key': apikey})
 
-        # Try a simple request to see if the API key works
-        # Keep the info, in case we need it later
-        self.version = self.get_version()
+            # Try a simple request to see if the API key works
+            # Keep the info, in case we need it later
+            self.version = self.get_version()
 
     def _get(self, path, params=None):
         """

--- a/octorest/client.py
+++ b/octorest/client.py
@@ -264,7 +264,7 @@ class OctoRest:
             return (AuthorizationRequestPollingResult.NOPE, None)
         elif response.status_code == 200:
             keyResponse = response.json()
-            apikey = keyResponse['apikey']
+            apikey = keyResponse['api_key'] # At the time of writing this, the official documentation in the link above says this key is named 'apikey', but wireshark says differently
             return (AuthorizationRequestPollingResult.GRANTED, apikey)
         else:
             raise Exception("Received response with unexpected status code")

--- a/octorest/client.py
+++ b/octorest/client.py
@@ -36,11 +36,23 @@ class OctoRest:
         self.session = session or requests.Session()
         
         if apikey:
-            self.session.headers.update({'X-Api-Key': apikey})
+            self.loadApiKey(apikey)
 
-            # Try a simple request to see if the API key works
-            # Keep the info, in case we need it later
-            self.version = self.get_version()
+    def loadApiKey(self, apiKey: str) -> None:
+        """Use the given API key for all future communication with the OctoPrint server.
+
+        Raises TypeError if 'apiKey' is None or empty.
+        Raises RuntimeError if the API key is rejected by the server.
+
+        """
+        if not apiKey:
+            raise TypeError('Required argument \'apiKey\' not found or empty')
+
+        self.session.headers.update({'X-Api-Key': apiKey})
+
+        # Try a simple request to see if the API key works
+        # Keep the info, in case we need it later
+        self.version = self.get_version()
 
     def _get(self, path, params=None):
         """

--- a/octorest/client.py
+++ b/octorest/client.py
@@ -43,9 +43,9 @@ class OctoRest:
         self.session = session or requests.Session()
         
         if apikey:
-            self.loadApiKey(apikey)
+            self.load_api_key(apikey)
 
-    def loadApiKey(self, apikey: str) -> None:
+    def load_api_key(self, apikey: str) -> None:
         """Use the given API key for all future communication with the OctoPrint server.
 
         Raises TypeError if 'apikey' is None or empty.
@@ -208,7 +208,7 @@ class OctoRest:
     ### APPS - APPLICATION KEYS PLUGIN WORKFLOW ###
     ###############################################
 
-    def probeAppKeysWorkflowSupport(self) -> bool:
+    def probe_app_keys_workflow_support(self) -> bool:
         """Check if the Application Keys Plugin workflow is supported
         https://docs.octoprint.org/en/master/bundledplugins/appkeys.html#probe-for-workflow-support
 
@@ -224,7 +224,7 @@ class OctoRest:
         
         return False
 
-    def startAuthorizationProcess(self, app: str, user: Optional[str] = None) -> str:
+    def start_authorization_process(self, app: str, user: Optional[str] = None) -> str:
         """Starts the authorization process
         https://docs.octoprint.org/en/master/bundledplugins/appkeys.html#start-authorization-process
 
@@ -255,7 +255,7 @@ class OctoRest:
 
         return location
     
-    def pollAuthRequestDecision(self, url: str) -> Tuple[AuthorizationRequestPollingResult, Optional[str]]:
+    def poll_auth_request_decision(self, url: str) -> Tuple[AuthorizationRequestPollingResult, Optional[str]]:
         """Check for an authorization request decision
         https://docs.octoprint.org/en/master/bundledplugins/appkeys.html#poll-for-decision-on-existing-request
 
@@ -272,13 +272,13 @@ class OctoRest:
         elif response.status_code == 404:
             return (AuthorizationRequestPollingResult.NOPE, None)
         elif response.status_code == 200:
-            keyResponse = response.json()
-            apikey = keyResponse['api_key'] # At the time of writing this, the official documentation in the link above says this key is named 'apikey', but wireshark says differently
-            return (AuthorizationRequestPollingResult.GRANTED, apikey)
+            key_response = response.json()
+            api_key = key_response['api_key'] # At the time of writing this, the official documentation in the link above says this key is named 'apikey', but wireshark says differently
+            return (AuthorizationRequestPollingResult.GRANTED, api_key)
         else:
             raise Exception("Received response with unexpected status code")
     
-    def tryGetApiKey(self, appName: str, user: Optional[str], timeout: int = 60) -> Tuple[WorkflowAppKeyRequestResult, Optional[str]]:
+    def try_get_api_key(self, appName: str, user: Optional[str], timeout: int = 60) -> Tuple[WorkflowAppKeyRequestResult, Optional[str]]:
         """ Run the Application Keys Plugin Workflow
 
         app: This parameter should be a human readable identifier to use for the application requesting access.
@@ -298,24 +298,24 @@ class OctoRest:
         Returns a tuple who's first item an enum representing the result type,
         and if the result type is GRANTED, the tuple's second item is the API key.
         """
-        workflowSupported = self.probeAppKeysWorkflowSupport()
+        workflow_supported = self.probe_app_keys_workflow_support()
 
-        if not workflowSupported:
+        if not workflow_supported:
             return (WorkflowAppKeyRequestResult.WORKFLOW_UNSUPPORTED, None)
             
-        pollingUrl = self.startAuthorizationProcess(appName, user)
+        polling_url = self.start_authorization_process(appName, user)
         
         interval = 1
         elapsed = 0
         
         while elapsed < timeout:
-            (pollingResult, apikey) = self.pollAuthRequestDecision(pollingUrl)
+            (polling_result, api_key) = self.poll_auth_request_decision(polling_url)
 
-            if pollingResult == AuthorizationRequestPollingResult.NOPE:
+            if polling_result == AuthorizationRequestPollingResult.NOPE:
                 return (WorkflowAppKeyRequestResult.NOPE, None)
 
-            if pollingResult == AuthorizationRequestPollingResult.GRANTED:
-                return (WorkflowAppKeyRequestResult.GRANTED, apikey)
+            if polling_result == AuthorizationRequestPollingResult.GRANTED:
+                return (WorkflowAppKeyRequestResult.GRANTED, api_key)
 
             sleep(interval)
             elapsed += interval

--- a/octorest/client.py
+++ b/octorest/client.py
@@ -38,17 +38,17 @@ class OctoRest:
         if apikey:
             self.loadApiKey(apikey)
 
-    def loadApiKey(self, apiKey: str) -> None:
+    def loadApiKey(self, apikey: str) -> None:
         """Use the given API key for all future communication with the OctoPrint server.
 
-        Raises TypeError if 'apiKey' is None or empty.
+        Raises TypeError if 'apikey' is None or empty.
         Raises RuntimeError if the API key is rejected by the server.
 
         """
-        if not apiKey:
-            raise TypeError('Required argument \'apiKey\' not found or empty')
+        if not apikey:
+            raise TypeError('Required argument \'apikey\' not found or empty')
 
-        self.session.headers.update({'X-Api-Key': apiKey})
+        self.session.headers.update({'X-Api-Key': apikey})
 
         # Try a simple request to see if the API key works
         # Keep the info, in case we need it later
@@ -264,8 +264,8 @@ class OctoRest:
             return (AuthorizationRequestPollingResult.NOPE, None)
         elif response.status_code == 200:
             keyResponse = response.json()
-            apiKey = keyResponse['apiKey']
-            return (AuthorizationRequestPollingResult.GRANTED, apiKey)
+            apikey = keyResponse['apikey']
+            return (AuthorizationRequestPollingResult.GRANTED, apikey)
         else:
             raise Exception("Received response with unexpected status code")
     

--- a/octorest/client.py
+++ b/octorest/client.py
@@ -23,7 +23,7 @@ class OctoRest:
         If a session is provided, it will be used (mostly for testing)
         """
         if not url:
-            raise TypeError('Required argument \'url\' not found or emtpy')
+            raise TypeError('Required argument \'url\' not found or empty')
 
         parsed = urlparse.urlparse(url)
         if parsed.scheme not in ['http', 'https']:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name='octorest',
     version='0.3',
     description='Client library for OctoPrint REST API',
-    long_description=''.join(open('README.rst').readlines()),
+    long_description=''.join(open('README.rst', encoding='utf-8').readlines()),
     long_description_content_type='text/x-rst',
     keywords='octoprint, 3d printing',
     author='Miro Hrončok, Jiří Makarius, Douglas Brion',


### PR DESCRIPTION
Following Issue #7 , I implemented all the necessary methods needed for an OctoPrint app developer to get an API key using the recommended workflow. I even implemented a wrapper method that handles most of the workflow.

In addition, a small bugfix is included for a problem with setup.py - now reading the content of `README.rst` no longer relies on the system's default encoding, and instead `utf-8` is used explicitly. (This bug broke the package's installation process on some machines, including mine)