### PR TITLE
Add printer_profile() procedure to retrieve single profile

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,6 +175,7 @@ A check list of the features currently implemented can be seen below.
     - [X] Send an arbitrary command to the printer
 * Printer profile operations
     - [X] Retrieve all printer profiles
+    - [X] Retrieve specific printer profile
     - [ ] Add a new printer profile
     - [ ] Update an existing printer profile
     - [X] Remove an existing printer profile

--- a/octorest/client.py
+++ b/octorest/client.py
@@ -1154,6 +1154,17 @@ class OctoRest:
         """
         return self._get('/api/printerprofiles')
     
+    def printer_profile(self, profile=None):
+        """Retrieve specific printer profile
+        https://docs.octoprint.org/en/master/api/printerprofiles.html#retrieve-a-single-printer-profile
+
+        Retrieves a single, existing printer profile.
+        """
+        # Use default if none given
+        if profile is None:
+            profile='_default'
+        return self._get('/api/printerprofiles/{}'.format(profile))
+
     def add_printer_profile(self, profile_data):
         """Add a new printer profile
         http://docs.octoprint.org/en/master/api/printerprofiles.html#add-a-new-printer-profile


### PR DESCRIPTION
Function takes single (optional) argument to retrieve a specific profile or __\_default__