### PR TITLE
Fix send method of socket client implementations

### DIFF
--- a/octorest/websocket.py
+++ b/octorest/websocket.py
@@ -52,4 +52,4 @@ class WebSocketEventHandler(SockJSClient):
         Sends data, currently not working properly.
         OctoPrint server is unable to parse.
         """
-        self.socket.send(json.dumps(data))
+        self.socket.send(json.dumps([json.dumps(data)]))

--- a/octorest/xhrstreaming.py
+++ b/octorest/xhrstreaming.py
@@ -69,5 +69,5 @@ class XHRStreamingEventHandler(SockJSClient):
         print("SENDING")
         url = self.url.format(protocol="https" if self.secure else "http",
                               method="xhr_send")
-        response = self.socket.post(url, data=json.dumps(data))
+        response = self.socket.post(url, data=json.dumps([json.dumps(data)]))
         return response

--- a/octorest/xhrstreaminggenerator.py
+++ b/octorest/xhrstreaminggenerator.py
@@ -64,5 +64,5 @@ class XHRStreamingGenerator:
         OctoPrint server returns 404
         """
         url = '/'.join((self.url, 'xhr_send'))
-        response = self.session.post(url, data=json.dumps(data))
+        response = self.session.post(url, data=json.dumps([json.dumps(data)]))
         return response


### PR DESCRIPTION
The sent message has to be a JSON encoded list of JSON encoded payloads for the server to accept it. I've tested the Websocket implementation and just assume it's the same for the others.