### PR TITLE
Fix File Upload flags

### DIFF
--- a/octorest/client.py
+++ b/octorest/client.py
@@ -482,7 +482,6 @@ class OctoRest:
         payload = {'recursive': str(recursive).lower()}
         return self._get('/api/files/{}/{}'.format(location, filename), params=payload)
 
-
     def upload(self, file, *, location='local',
                select=False, print=False, userdata=None, path=None):
         """Upload file or create folder
@@ -492,18 +491,14 @@ class OctoRest:
         It can be a path or a tuple with a filename and a file-like object
         """
         with self._file_tuple(file) as file_tuple:
-            files = {'file': file_tuple}
-            data = {
-                'select': str(select).lower(),
-                'print': str(print).lower()
-            }
+            files = {'file': file_tuple, 'select': (None, select), 'print': (None, print)}
             if userdata:
-                data['userdata'] = userdata
+                files['userdata'] = (None, userdata)
             if path:
-                data['path'] = path
+                files['path'] = (None, path)
 
             return self._post('/api/files/{}'.format(location),
-                              files=files, json=data)
+                              files=files)
 
     def new_folder(self, folder_name, location='local'):
         """Upload file or create folder


### PR DESCRIPTION
Moved flags into the 'files' parameter of client.upload(): `select, print, userdata, path`

According to the OctoRest API documentation for [file uploads](https://docs.octoprint.org/en/master/api/files.html#upload-file-or-create-folder), the upload request is expected to be type `Content-Type: multipart/form-data`. 

When using this Content-Type, non-file data is expected to be added into the multipart form alongside the file to be uploaded. The [requests module](https://github.com/kennethreitz/requests/blob/master/requests/api.py#L16) can accept a 2-tuple, 3-tuple or 4-tuple value for `file-tuple`. The first arg in the tuple is for the _filename_ field, which is used only for the file being uploaded. For each non-file data we wish to submit, we need to pass "None" in place of our filename arg since it's required in order for the data to be accepted.

Fixes #6