### PR TITLE
Add the currentuser endpoint

### DIFF
--- a/octorest/client.py
+++ b/octorest/client.py
@@ -172,6 +172,18 @@ class OctoRest:
         Retrieve information regarding server and API version
         """
         return self._get('/api/version')
+
+    ##############
+    ### LOGIN  ###
+    ##############
+
+    def current_user(self):
+        """Current User
+        https://docs.octoprint.org/en/master/api/general.html#current-user
+
+        Retrieves information about the current user.
+        """
+        return self._get('/api/currentuser')
     
     ###########################
     ### APPS - SESSION KEYS ###


### PR DESCRIPTION
Adds the /api/currentuser endpoint, allowing a session to determine information about the active user based on login or api key.