### PR TITLE
Fix new_folder command by changing POST type

### DIFF
--- a/octorest/client.py
+++ b/octorest/client.py
@@ -523,7 +523,7 @@ class OctoRest:
         data = {
             'foldername': folder_name,
         }
-        return self._post('/api/files/{}'.format(location), json=data)
+        return self._post('/api/files/{}'.format(location), data=data)
 
     def select(self, location, *, print=False):
         """Issue a file command


### PR DESCRIPTION
`new_folder` was incorrectly sending it's data as JSON, when it should
have been sent as form data according to the Octoprint API spec.
Changing from `json=data` to `data=data` in the `_post` invocation
corrects this.