### PR TITLE
Add flag to disable checking HTTPS certificate

### DIFF
--- a/examples/basic/basic.py
+++ b/examples/basic/basic.py
@@ -8,6 +8,14 @@ def make_client():
     except Exception as e:
         print(e)
 
+def make_client_https():
+    try:
+        # make Octopi connection via HTTPS with no verify certificate (i.e. selfsigned)
+        client = OctoRest(url="https://octopi.local", apikey="YouShallNotPass", verify=False)
+        return client
+    except Exception as e:
+        print(e)
+
 def get_version():
     client = make_client()
     message = "You are using OctoPrint v" + client.version['server'] + "\n"

--- a/octorest/client.py
+++ b/octorest/client.py
@@ -4,6 +4,7 @@ from urllib import parse as urlparse
 from typing import Optional, Tuple
 from enum import Enum
 from time import sleep
+import urllib3
 
 import requests
 
@@ -23,12 +24,14 @@ class OctoRest:
     Encapsulates communication with one OctoPrint instance
     """
 
-    def __init__(self, *, url=None, apikey=None, session=None):
+    def __init__(self, *, url=None, apikey=None, session=None, verify=True):
         """
         Initialize the object with URL and API key
 
         If a session is provided, it will be used (mostly for testing)
         """
+        self.verify = verify
+
         if not url:
             raise TypeError('Required argument \'url\' not found or empty')
 
@@ -44,6 +47,7 @@ class OctoRest:
         
         if apikey:
             self.load_api_key(apikey)
+
 
     def load_api_key(self, apikey: str) -> None:
         """Use the given API key for all future communication with the OctoPrint server.
@@ -73,7 +77,8 @@ class OctoRest:
         Returns JSON decoded data
         """
         url = urlparse.urljoin(self.url, path)
-        response = self.session.get(url, params=params)
+        if not self.verify : urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        response = self.session.get(url, params=params, verify=self.verify)
         self._check_response(response)
 
         return response.json()
@@ -90,7 +95,8 @@ class OctoRest:
         Returns JSON decoded data
         """
         url = urlparse.urljoin(self.url, path)
-        response = self.session.post(url, data=data, files=files, json=json)
+        if not self.verify : urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        response = self.session.post(url, data=data, files=files, json=json, verify=self.verify)
         self._check_response(response)
 
         if ret:


### PR DESCRIPTION
Add flag to disable checking HTTPS certificate (verify=False to disable checking, verify=True to enable (by default)): client=OctoRest(url="https://octopi.local",apikey="YouShallNotPass",verify=False)
To avoid error like: HTTPSConnectionPool(host='octopi.local', port=443): Max retries exceeded with url: /api/version (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate (_ssl.c:992)')))
